### PR TITLE
devcontainerのVSCode拡張機能の更新

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
   "customizations": {
     "vscode": {
       "extensions": [
-        "rebornix.Ruby",
+        "Shopify.ruby-lsp",
         "redhat.vscode-yaml",
         "VisualStudioExptTeam.vscodeintellicode",
         "esbenp.prettier-vscode"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 ## VSCode extensions
 
-- [rebornix.Ruby](https://marketplace.visualstudio.com/items?itemName=rebornix.Ruby)
+- [Shopify.ruby-lsp](https://marketplace.visualstudio.com/items?itemName=Shopify.ruby-lsp)
 - [redhat.vscode-yaml](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml)
 - [VisualStudioExptTeam.vscodeintellicode](https://marketplace.visualstudio.com/items?itemName=VisualStudioExptTeam.vscodeintellicode)
 - [esbenp.prettier-vscode](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)


### PR DESCRIPTION
## 作業内容

- 2023-11現在、`devcontainer.json`で指定されているVSCodeの拡張機能：`rebornix.Ruby`は公式に非推奨となっているため、公式に推奨されている拡張機能：`Shopify.ruby-lsp`に更新しました。

### 関連リンク

- [Railsのリポジトリ](https://github.com/rails/rails/blob/139c5678aa5d9a4209ca06919abea7a9da449b36/.devcontainer/devcontainer.json#L32-L39)でも本PRで更新したものと同様の拡張機能が指定されているようです。

- VSCodeの公式では以下のページに記載があります。
  - https://code.visualstudio.com/docs/languages/ruby
- また、1次情報ではありませんが、以下の記事なども詳しいです。
  - https://zenn.dev/necocoa/articles/vscode-ruby-lsp

### 備考

- このリポジトリの運用ルールがわかっていないこともあり、不躾にPull Requestを作成してしまっていたらすみません。その場合は遠慮なくCloseください。
- [Rails Tutorialの対象ページ](https://railstutorial.jp/help#devcontainer)からこのリポジトリを知り、活用させていただきました。ありがとうございます。